### PR TITLE
fix: remove kill switch in veboost

### DIFF
--- a/contracts/VotingEscrowDelegation.vy
+++ b/contracts/VotingEscrowDelegation.vy
@@ -104,7 +104,6 @@ boost_tokens: HashMap[uint256, Token]
 
 admin: public(address)  # Can and will be a smart contract
 future_admin: public(address)
-is_killed: public(bool)
 
 totalSupply: public(uint256)
 # use totalSupply to determine the length
@@ -737,9 +736,6 @@ def adjusted_balance_of(_account: address) -> uint256:
     """
     vecrv_balance: int256 = convert(VotingEscrow(VOTING_ESCROW).balanceOf(_account), int256)
 
-    if self.is_killed:
-        return convert(vecrv_balance, uint256)
-
     boost: Boost = self.boost[_account]
     time: int256 = convert(block.timestamp, int256)
 
@@ -951,16 +947,6 @@ def accept_transfer_ownership():
     future_admin: address = self.future_admin
     assert msg.sender == future_admin
     self.admin = future_admin
-
-
-@external
-def set_killed(_killed: bool):
-    """
-    @notice Set the kill status of the contract
-    @param _killed Kill state to put the contract in, True = killed, False = alive
-    """
-    assert msg.sender == self.admin
-    self.is_killed = _killed
 
 
 @external

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,4 @@
 import brownie
-import pytest
 
 
 def test_commit_new_owner(alice, bob, veboost):
@@ -23,25 +22,6 @@ def test_accept_transfer_ownership_guarded(alice, bob, veboost):
     veboost.commit_transfer_ownership(bob, {"from": alice})
     with brownie.reverts():
         veboost.accept_transfer_ownership({"from": alice})
-
-
-@pytest.mark.usefixtures("boost_bob")
-def test_set_killed(alice, bob, veboost):
-    assert veboost.adjusted_balance_of(bob) > 0
-
-    veboost.set_killed(True, {"from": alice})
-    assert veboost.adjusted_balance_of(bob) == 0
-
-    veboost.set_killed(False, {"from": alice})
-    assert veboost.adjusted_balance_of(bob) > 0
-
-
-def test_set_killed_guarded(bob, veboost):
-    with brownie.reverts():
-        veboost.set_killed(True, {"from": bob})
-
-    with brownie.reverts():
-        veboost.set_killed(False, {"from": bob})
 
 
 def test_set_base_uri(alice, veboost):


### PR DESCRIPTION
Removes the kill switch in the delegation contract.
It will be reimplemented in a proxy contract