### PR TITLE
Update _burn_boost to handle expiries correctly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-yaml
       - id: check-json
   - repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/contracts/VotingEscrowDelegation.vy
+++ b/contracts/VotingEscrowDelegation.vy
@@ -308,7 +308,7 @@ def _burn_boost(_token_id: uint256, _delegator: address, _receiver: address, _bi
     next_expiry: uint256 = expiry_data % 2 ** 128
     active_delegations: uint256 = shift(expiry_data, -128) - 1
 
-    expiries: uint256 = self.account_expiries[_delegator][expire_time]
+    expiries: uint256 = self.account_expiries[_delegator][expire_time] - 1
 
     if active_delegations != 0 and expire_time == next_expiry and expiries == 0:
         # Will be passed if
@@ -330,7 +330,7 @@ def _burn_boost(_token_id: uint256, _delegator: address, _receiver: address, _bi
         next_expiry = 0
 
     self.boost[_delegator].expiry_data = shift(active_delegations, 128) + next_expiry
-    self.account_expiries[_delegator][expire_time] = expiries - 1
+    self.account_expiries[_delegator][expire_time] = expiries
 
 
 @internal

--- a/tests/boosts/test_batch_cancel_boosts.py
+++ b/tests/boosts/test_batch_cancel_boosts.py
@@ -43,7 +43,7 @@ def test_delegator_can_cancel_after_cancel_time_or_expiry(
             alice,
             bob,
             1_000,
-            alice_unlock_time - (WEEK * i ** 2),
+            alice_unlock_time - (WEEK * i**2),
             alice_unlock_time,
             i,
             {"from": alice},
@@ -83,7 +83,7 @@ def test_third_parties_can_only_cancel_past_expiry(
             bob,
             1_000,
             0,
-            alice_unlock_time - (WEEK * i ** 2),
+            alice_unlock_time - (WEEK * i**2),
             i,
             {"from": alice},
         )

--- a/tests/boosts/test_create_boost.py
+++ b/tests/boosts/test_create_boost.py
@@ -32,31 +32,6 @@ def test_create_a_boost(alice, bob, chain, alice_unlock_time, veboost, vecrv):
     assert veboost.token_expiry(token_id) == (alice_unlock_time // WEEK) * WEEK
 
 
-def test_add_new_boost_after_first_boost_expires(
-    alice, charlie, dave, chain, alice_unlock_time, veboost
-):
-
-    token = veboost.get_token_id(alice, 0)
-    token_expiry = veboost.token_expiry(token)
-
-    # fast forward to a bit before when the boost expires
-    chain.mine(timestamp=token_expiry - DAY)
-
-    # give charlie 10% of alice's vecrv boost
-    charlie_expiration = alice_unlock_time - 20 * WEEK
-    assert charlie_expiration != token_expiry  # we want a new expiration time
-    veboost.create_boost(alice, charlie, 1_000, 0, charlie_expiration, 1, {"from": alice})
-
-    # now go to first expiry
-    chain.mine(timestamp=token_expiry + 1)
-    assert veboost.token_boost(token) < 0  # in principle this should become negative
-    veboost.cancel_boost(token, {"from": alice})  # anyone can cancel boost position if negative
-
-    # give dave a boost
-    dave_expiration = alice_unlock_time - 10 * WEEK
-    veboost.create_boost(alice, dave, 1_000, 0, dave_expiration, 2, {"from": alice})
-
-
 def test_create_a_boost_updates_delegator_enumeration(alice, bob, alice_unlock_time, veboost):
     veboost.create_boost(alice, bob, 10_000, 0, alice_unlock_time, 0, {"from": alice})
     token_id = convert.to_uint(alice.address) << 96
@@ -178,3 +153,29 @@ def test_invalid_boost_percentage(alice, alice_unlock_time, veboost, pct, msg):
 def test_boost_zero_address_reverts(alice, alice_unlock_time, veboost):
     with brownie.reverts(dev_revert_msg="dev: minting to ZERO_ADDRESS disallowed"):
         veboost.create_boost(alice, ZERO_ADDRESS, 10_000, 0, alice_unlock_time, 0, {"from": alice})
+
+
+@pytest.mark.usefixtures("boost_bob")
+def test_add_new_boost_after_first_boost_expires(
+    alice, charlie, dave, chain, alice_unlock_time, veboost
+):
+
+    token = veboost.get_token_id(alice, 0)
+    token_expiry = veboost.token_expiry(token)
+
+    # fast forward to a bit before when the boost expires
+    chain.mine(timestamp=token_expiry - DAY)
+
+    # give charlie 10% of alice's vecrv boost
+    charlie_expiration = alice_unlock_time - 20 * WEEK
+    assert charlie_expiration != token_expiry  # we want a new expiration time
+    veboost.create_boost(alice, charlie, 1_000, 0, charlie_expiration, 1, {"from": alice})
+
+    # now go to first expiry
+    chain.mine(timestamp=token_expiry + 1)
+    assert veboost.token_boost(token) < 0  # in principle this should become negative
+    veboost.cancel_boost(token, {"from": alice})  # anyone can cancel boost position if negative
+
+    # give dave a boost
+    dave_expiration = alice_unlock_time - 10 * WEEK
+    veboost.create_boost(alice, dave, 1_000, 0, dave_expiration, 2, {"from": alice})

--- a/tests/boosts/test_state.py
+++ b/tests/boosts/test_state.py
@@ -173,7 +173,7 @@ class ContractState:
         # cancel time before expire time, expire time before lock expiry
         assert cancel_time <= expire_time <= lock_expiry
         assert expire_time >= timestamp + WEEK  # expire time greater than min delegation time
-        assert _id < 2 ** 96  # id with bounds
+        assert _id < 2**96  # id with bounds
 
         assert all(
             [t(timestamp) >= 0 for t in self.boost_tokens.values() if t.delegator == delegator]
@@ -344,7 +344,7 @@ class StateMachine:
         amount = total_supply // len(self.accounts)
         for account in self.accounts:
             self.crv.transfer(account, amount, {"from": self.accounts[0]})
-            self.crv.approve(self.vecrv, 2 ** 256 - 1, {"from": account})
+            self.crv.approve(self.vecrv, 2**256 - 1, {"from": account})
             # lock up half of each accounts balance for 3 years
             self.vecrv.create_lock(amount, chain.time() + 3 * YEAR, {"from": account})
 

--- a/tests/fixtures/constants.py
+++ b/tests/fixtures/constants.py
@@ -6,7 +6,7 @@ WEEK = DAY * 7
 
 @pytest.fixture(scope="session")
 def alice_lock_value():
-    return 1_000_000 * 10 ** 18
+    return 1_000_000 * 10**18
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def alice_unlock_time(chain):
 
 @pytest.fixture(scope="session")
 def bob_lock_value():
-    return 500_000 * 10 ** 18
+    return 500_000 * 10**18
 
 
 @pytest.fixture

--- a/tests/test_uint_to_string.py
+++ b/tests/test_uint_to_string.py
@@ -8,17 +8,17 @@ def uint_to_string(value: int) -> str:
         return "0"
 
     buffer = ""
-    max_len = len(str(2 ** 256 - 1))
+    max_len = len(str(2**256 - 1))
     digits = 0
     for i in range(1, max_len + 1):
-        if value // 10 ** i == 0:
+        if value // 10**i == 0:
             digits = i
             break
 
     # go backwards from end to start
     for i in range(max_len - 1, -1, -1):
         # get rid of everything below, then everything above
-        buffer += chr(((value // 10 ** i) % 10) + 48)
+        buffer += chr(((value // 10**i) % 10) + 48)
 
     return buffer[-digits:]
 

--- a/tests/token/test_enumeration_state.py
+++ b/tests/token/test_enumeration_state.py
@@ -31,7 +31,7 @@ class StateMachine:
             self.crv.transfer(acct, dividend, {"from": self.alice})
 
         for acct in self.accounts:
-            self.crv.approve(self.vecrv, 2 ** 256 - 1, {"from": acct})
+            self.crv.approve(self.vecrv, 2**256 - 1, {"from": acct})
             self.vecrv.create_lock(dividend, chain.time() + 86400 * 365, {"from": acct})
 
     def rule_mint(self, st_addr, st_id):


### PR DESCRIPTION
### Issue:
In the conditions line [#313](https://github.com/curvefi/curve-veBoost/blob/0e51be10638df2479d9e341c07fafa940ef58596/contracts/VotingEscrowDelegation.vy#L313), `next_expiry` should be updated is the Boost being canceled is the current `next_expiry`, there are still other Boosts active, and there is no more Boost expiring at the same time.
But because of how the `expiries` value is fetched just before, if the Boost being canceled is the the only one expiring at `expire_time`, the value `expiries` will be `1`, and not `0` (since the current Boost being canceled was not removed from that count yet), making so the `next_expiry` is not updated.
If the delegator has other active Boosts while Boosts are canceled, then it will not be able to create other Boosts before the expiry of all current active Boosts (since `next_expiry` is reset to 0 when the last Boost is canceled).

### Fix:
Decrement the `expiries` value when loaded from storage, directly accounting for the Boost being canceled before trying to update `next_expiry`